### PR TITLE
Update install-nix-action to v20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0
  
     - name: Install Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v20
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes


### PR DESCRIPTION
Fixes

```
Error: Action failed with error: Error: Unable to locate executable
file: cachix. Please verify either the file path exists or the file can
be found within a directory specified by the PATH environment variable.
Also check the file mode to verify the file is executable.
```